### PR TITLE
Add: Automatic hackathon status based on current date & time

### DIFF
--- a/backend/src/api/hackathon/content-types/hackathon/schema.json
+++ b/backend/src/api/hackathon/content-types/hackathon/schema.json
@@ -58,14 +58,6 @@
       "relation": "manyToMany",
       "target": "api::tag.tag",
       "inversedBy": "hackathons"
-    },
-    "status": {
-      "type": "enumeration",
-      "enum": [
-        "Ongoing",
-        "Past",
-        "Upcoming"
-      ]
     }
   }
 }

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -976,7 +976,6 @@ export interface ApiHackathonHackathon extends Schema.CollectionType {
       'manyToMany',
       'api::tag.tag'
     >;
-    status: Attribute.Enumeration<['Ongoing', 'Past', 'Upcoming']>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;

--- a/frontend/src/app/hackclub_nitk/page.jsx
+++ b/frontend/src/app/hackclub_nitk/page.jsx
@@ -8,6 +8,22 @@ export default async function HackClubDashBoard() {
     })
     let hackathons = (await response.json()).data;
 
+    const now = new Date();
+    hackathons = hackathons.map(hackathon => {
+        const startTime = new Date(hackathon.attributes.start_time);
+        const endTime = new Date(hackathon.attributes.end_time);
+
+        if (now >= startTime && now <= endTime) {
+            hackathon.attributes.status = "Ongoing";
+        } else if (now < startTime) {
+            hackathon.attributes.status = "Upcoming";
+        } else {
+            hackathon.attributes.status = "Past";
+        }
+
+        return hackathon;
+    });
+
     return (
         <>
             <section className="w-full h-[80vh] flex items-center justify-center bg-accent-900 bg-cover bg-center">


### PR DESCRIPTION
This PR addresses issue #49 by automatically assigning status to hackathons (Upcoming, Ongoing, Past) based on the current date and time. This removes the need for manual updates. This PR also removes the `status` attribute from the `hackathon` schema.