### PR TITLE
Resolving Event slug issues (issue#48)

### DIFF
--- a/frontend/src/app/events/[slug]/loading.js
+++ b/frontend/src/app/events/[slug]/loading.js
@@ -1,0 +1,5 @@
+import FullScreenLoader from "@/components/FullScreenLoader"
+
+export default function Component() {
+    return <FullScreenLoader/>
+}

--- a/frontend/src/app/events/[slug]/page.js
+++ b/frontend/src/app/events/[slug]/page.js
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default async function Page({ params }) {
+    redirect(`/events#${params.slug}`);
+}

--- a/frontend/src/app/events/[slug]/page.js
+++ b/frontend/src/app/events/[slug]/page.js
@@ -1,4 +1,38 @@
 import { redirect } from "next/navigation";
+import { getEvent } from "@/helpers/getEvent";
+import { getStrapiMedia } from "@/helpers/strapi_api";
+
+export async function generateMetadata({ params }) {
+
+    let slug = params.slug.split('-');
+    let event_id = slug[slug.length-1];
+    let event = await getEvent(event_id);
+    const { title, body, date_time, sigs } = event.attributes
+    const cover_image = getStrapiMedia(event.attributes.cover_images.data[0]?.attributes.url)
+
+    return {
+        metadataBase: new URL('https://webclub.nitk.ac.in'),
+        title: title,
+        description: body.substring(0, 200),
+        openGraph: {
+          title: title,
+          description: body.substring(0, 200),
+          url: `https://webclub.nitk.ac.in/events/${params.slug}`,
+          siteName: "WebClub NITK Event",
+          images: [
+            {
+              url: cover_image || 'https://webclub.nitk.ac.in/default-og-image.png',
+              width: 1200,
+              height: 630,
+              alt: title,
+            },
+          ],
+          locale: 'en_US',
+          type: 'article',
+          publishedTime: date_time,
+        },
+      }
+}
 
 export default async function Page({ params }) {
     redirect(`/events#${params.slug}`);

--- a/frontend/src/components/events/ExpandableEventCard.jsx
+++ b/frontend/src/components/events/ExpandableEventCard.jsx
@@ -6,19 +6,24 @@ import { AnimatePresence, motion } from "framer-motion"
 
 export default function ExpandableEventCard ({ event }) {
     let [ modalInitial, setModalInitial ] = useState(false)
+
+    const titl = event.title.split(' ');
+    let slug = titl.join('-') +  `-${event.id}`;
+
     
     useEffect(() => {
-        if (getHashID() == event.id) 
+        if (getHashID() == slug) 
             setModalInitial({ x: 0, y: 0, width: 0, height: 0})
     }, [])
 
     useEffect(() => {
         if (modalInitial) {
             document.body.style.overflow = "hidden"
-            window.location.hash = event.id
+            window.location.hash = slug
         } else {
             document.body.style.overflow = "auto"
-            if (getHashID() == event.id) {
+            window.location.hash = ""
+            if (getHashID() === slug) {
                 let y = window.scrollY
                 window.location.hash = ""
                 window.scrollTo(0, y)
@@ -52,5 +57,5 @@ export default function ExpandableEventCard ({ event }) {
 
 
 function getHashID () {
-    return parseInt(window.location.hash.slice(1))
+    return window.location.hash.slice(1);
 }


### PR DESCRIPTION
The event slug was just the id of the event but now it is the title of the event separated by '-' plus the id. When the user clicks on the event card they are redirected to a "/events#params.slug" page. 